### PR TITLE
Add basic WorldStrand profile with custom inspector

### DIFF
--- a/Assets/WorldStrands/Editor/WorldStrandProfileEditor.cs
+++ b/Assets/WorldStrands/Editor/WorldStrandProfileEditor.cs
@@ -1,0 +1,46 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace WorldStrands.Editor
+{
+    [CustomEditor(typeof(WorldStrandProfile))]
+    public class WorldStrandProfileEditor : UnityEditor.Editor
+    {
+        SerializedProperty pointsProp;
+
+        void OnEnable()
+        {
+            pointsProp = serializedObject.FindProperty("points");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.LabelField("Profile Points", EditorStyles.boldLabel);
+
+            for (int i = 0; i < pointsProp.arraySize; i++)
+            {
+                SerializedProperty point = pointsProp.GetArrayElementAtIndex(i);
+                SerializedProperty yProp = point.FindPropertyRelative("y");
+                SerializedProperty colorProp = point.FindPropertyRelative("color");
+
+                EditorGUILayout.BeginHorizontal();
+                yProp.floatValue = EditorGUILayout.FloatField(yProp.floatValue);
+                colorProp.colorValue = EditorGUILayout.ColorField(colorProp.colorValue);
+                if (GUILayout.Button("-", GUILayout.Width(20)))
+                {
+                    pointsProp.DeleteArrayElementAtIndex(i);
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            if (GUILayout.Button("Add Point"))
+            {
+                pointsProp.arraySize++;
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/WorldStrands/WorldStrandProfile.cs
+++ b/Assets/WorldStrands/WorldStrandProfile.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WorldStrands
+{
+    [CreateAssetMenu(fileName = "WorldStrandProfile", menuName = "WorldStrands/Profile", order = 0)]
+    public class WorldStrandProfile : ScriptableObject
+    {
+        [System.Serializable]
+        public struct ProfilePoint
+        {
+            public float y;
+            public Color color;
+        }
+
+        public List<ProfilePoint> points = new List<ProfilePoint>
+        {
+            new ProfilePoint { y = 0f, color = Color.white },
+            new ProfilePoint { y = -0.2f, color = Color.white }
+        };
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # worldstrands
+
+This repository contains a prototype Unity tool for generating stylized ropes with prayer flags. The initial implementation includes a `WorldStrandProfile` ScriptableObject and its custom Inspector UI. This profile defines the vertical cross‑section of a strand with positions and per‑vertex colors.
+
+Scripts are located under `Assets/WorldStrands/`.


### PR DESCRIPTION
## Summary
- implement `WorldStrandProfile` ScriptableObject storing a list of profile points
- add `WorldStrandProfileEditor` to edit point positions and colors in the Inspector
- document the new system in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874b7257f908332b5701d4d7e2a81a3