### PR TITLE
Add strand path component

### DIFF
--- a/assets/worldStrands/editor/worldStrandPathEditor.cs
+++ b/assets/worldStrands/editor/worldStrandPathEditor.cs
@@ -1,0 +1,51 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace WorldStrands.Editor
+{
+    [CustomEditor(typeof(WorldStrandPath))]
+    public class WorldStrandPathEditor : UnityEditor.Editor
+    {
+        SerializedProperty pointsProp;
+
+        void OnEnable()
+        {
+            pointsProp = serializedObject.FindProperty("points");
+        }
+
+        void OnSceneGUI()
+        {
+            WorldStrandPath path = (WorldStrandPath)target;
+
+            for (int i = 0; i < pointsProp.arraySize; i++)
+            {
+                SerializedProperty pointProp = pointsProp.GetArrayElementAtIndex(i);
+                Vector3 world = path.transform.TransformPoint(pointProp.vector3Value);
+                EditorGUI.BeginChangeCheck();
+                world = Handles.PositionHandle(world, Quaternion.identity);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    Undo.RecordObject(path, "Move Point");
+                    pointProp.vector3Value = path.transform.InverseTransformPoint(world);
+                    serializedObject.ApplyModifiedProperties();
+                    path.UpdateMesh();
+                }
+            }
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("profile"));
+            EditorGUILayout.PropertyField(pointsProp, true);
+
+            if (GUILayout.Button("Update Mesh"))
+            {
+                ((WorldStrandPath)target).UpdateMesh();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/assets/worldStrands/worldStrandPath.cs
+++ b/assets/worldStrands/worldStrandPath.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WorldStrands
+{
+    [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
+    public class WorldStrandPath : MonoBehaviour
+    {
+        public WorldStrandProfile profile;
+
+        public List<Vector3> points = new List<Vector3>
+        {
+            new Vector3(-1f, 0f, 0f),
+            new Vector3(1f, 0f, 0f)
+        };
+
+        Mesh _mesh;
+
+        void OnValidate()
+        {
+            UpdateMesh();
+        }
+
+        public void UpdateMesh()
+        {
+            if (profile == null || points.Count < 2 || profile.points.Count < 2)
+            {
+                return;
+            }
+
+            if (_mesh == null)
+            {
+                _mesh = new Mesh();
+                _mesh.name = "WorldStrandPathMesh";
+                GetComponent<MeshFilter>().sharedMesh = _mesh;
+            }
+
+            int segments = points.Count;
+            int profileCount = profile.points.Count;
+
+            Vector3[] verts = new Vector3[segments * profileCount];
+            Color[] cols = new Color[verts.Length];
+            List<int> tris = new List<int>();
+
+            for (int i = 0; i < segments; i++)
+            {
+                for (int j = 0; j < profileCount; j++)
+                {
+                    var pp = profile.points[j];
+                    verts[i * profileCount + j] = points[i] + Vector3.up * pp.y;
+                    cols[i * profileCount + j] = pp.color;
+                }
+            }
+
+            for (int i = 0; i < segments - 1; i++)
+            {
+                for (int j = 0; j < profileCount - 1; j++)
+                {
+                    int v0 = i * profileCount + j;
+                    int v1 = i * profileCount + j + 1;
+                    int v2 = (i + 1) * profileCount + j;
+                    int v3 = (i + 1) * profileCount + j + 1;
+
+                    tris.Add(v0);
+                    tris.Add(v2);
+                    tris.Add(v1);
+
+                    tris.Add(v1);
+                    tris.Add(v2);
+                    tris.Add(v3);
+                }
+            }
+
+            _mesh.Clear();
+            _mesh.vertices = verts;
+            _mesh.colors = cols;
+            _mesh.triangles = tris.ToArray();
+            _mesh.RecalculateNormals();
+        }
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,7 @@
 This repository contains a prototype Unity tool for generating stylized ropes with prayer flags. The initial implementation includes a `WorldStrandProfile` ScriptableObject and its custom Inspector UI. This profile defines the vertical cross‑section of a strand with positions and per‑vertex colors.
 
 Scripts are located under `assets/worldStrands/`.
+
+## Strand Path Component
+
+`WorldStrandPath` is a `MonoBehaviour` that extrudes a `WorldStrandProfile` along a list of path points. Points can be adjusted directly in the Scene view and the generated mesh is stored in a `MeshFilter` on the same GameObject.


### PR DESCRIPTION
## Summary
- implement `WorldStrandPath` component that extrudes a `WorldStrandProfile` along a list of path points
- add a custom editor so points can be moved in the Scene view
- document new component in the README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6878dc42cd4883329040259d70c07383