### PR TITLE
Embed profile editor in path component

### DIFF
--- a/assets/worldStrands/editor/worldStrandPathEditor.cs
+++ b/assets/worldStrands/editor/worldStrandPathEditor.cs
@@ -7,10 +7,13 @@ namespace WorldStrands.Editor
     public class WorldStrandPathEditor : UnityEditor.Editor
     {
         SerializedProperty pointsProp;
+        SerializedProperty profileProp;
+        UnityEditor.Editor profileEditor;
 
         void OnEnable()
         {
             pointsProp = serializedObject.FindProperty("points");
+            profileProp = serializedObject.FindProperty("profile");
         }
 
         void OnSceneGUI()
@@ -37,7 +40,17 @@ namespace WorldStrands.Editor
         {
             serializedObject.Update();
 
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("profile"));
+            EditorGUILayout.PropertyField(profileProp);
+
+            if (profileProp.objectReferenceValue != null)
+            {
+                Editor.CreateCachedEditor(profileProp.objectReferenceValue, typeof(WorldStrandProfileEditor), ref profileEditor);
+                if (profileEditor != null)
+                {
+                    profileEditor.OnInspectorGUI();
+                }
+            }
+
             EditorGUILayout.PropertyField(pointsProp, true);
 
             if (GUILayout.Button("Update Mesh"))

--- a/readme.md
+++ b/readme.md
@@ -6,4 +6,4 @@ Scripts are located under `assets/worldStrands/`.
 
 ## Strand Path Component
 
-`WorldStrandPath` is a `MonoBehaviour` that extrudes a `WorldStrandProfile` along a list of path points. Points can be adjusted directly in the Scene view and the generated mesh is stored in a `MeshFilter` on the same GameObject.
+`WorldStrandPath` is a `MonoBehaviour` that extrudes a `WorldStrandProfile` along a list of path points. Points can be adjusted directly in the Scene view and the generated mesh is stored in a `MeshFilter` on the same GameObject. The inspector now embeds the profile editor so you can tweak cross‑section points without leaving the component.


### PR DESCRIPTION
## Summary
- let WorldStrandPath inspector draw the profile inspector
- document the combined editor in the readme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e0a960748332bfc0ff082d9d6ef0