### PR TITLE
Align class/namespace names with lowercase files

### DIFF
--- a/assets/worldStrands/editor/worldStrandPathEditor.cs
+++ b/assets/worldStrands/editor/worldStrandPathEditor.cs
@@ -1,10 +1,10 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace WorldStrands.Editor
+namespace worldStrands.editor
 {
-    [CustomEditor(typeof(WorldStrandPath))]
-    public class WorldStrandPathEditor : UnityEditor.Editor
+    [CustomEditor(typeof(worldStrandPath))]
+    public class worldStrandPathEditor : UnityEditor.Editor
     {
         SerializedProperty pointsProp;
         SerializedProperty profileProp;
@@ -18,7 +18,7 @@ namespace WorldStrands.Editor
 
         void OnSceneGUI()
         {
-            WorldStrandPath path = (WorldStrandPath)target;
+            worldStrandPath path = (worldStrandPath)target;
 
             for (int i = 0; i < pointsProp.arraySize; i++)
             {
@@ -44,7 +44,7 @@ namespace WorldStrands.Editor
 
             if (profileProp.objectReferenceValue != null)
             {
-                Editor.CreateCachedEditor(profileProp.objectReferenceValue, typeof(WorldStrandProfileEditor), ref profileEditor);
+                Editor.CreateCachedEditor(profileProp.objectReferenceValue, typeof(worldStrandProfileEditor), ref profileEditor);
                 if (profileEditor != null)
                 {
                     profileEditor.OnInspectorGUI();
@@ -55,7 +55,7 @@ namespace WorldStrands.Editor
 
             if (GUILayout.Button("Update Mesh"))
             {
-                ((WorldStrandPath)target).UpdateMesh();
+                ((worldStrandPath)target).UpdateMesh();
             }
 
             serializedObject.ApplyModifiedProperties();

--- a/assets/worldStrands/editor/worldStrandProfileEditor.cs
+++ b/assets/worldStrands/editor/worldStrandProfileEditor.cs
@@ -1,10 +1,10 @@
 using UnityEditor;
 using UnityEngine;
 
-namespace WorldStrands.Editor
+namespace worldStrands.editor
 {
-    [CustomEditor(typeof(WorldStrandProfile))]
-    public class WorldStrandProfileEditor : UnityEditor.Editor
+    [CustomEditor(typeof(worldStrandProfile))]
+    public class worldStrandProfileEditor : UnityEditor.Editor
     {
         SerializedProperty pointsProp;
 

--- a/assets/worldStrands/worldStrandPath.cs
+++ b/assets/worldStrands/worldStrandPath.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace WorldStrands
+namespace worldStrands
 {
     [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
-    public class WorldStrandPath : MonoBehaviour
+    public class worldStrandPath : MonoBehaviour
     {
-        public WorldStrandProfile profile;
+        public worldStrandProfile profile;
 
         public List<Vector3> points = new List<Vector3>
         {

--- a/assets/worldStrands/worldStrandProfile.cs
+++ b/assets/worldStrands/worldStrandProfile.cs
@@ -1,10 +1,10 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace WorldStrands
+namespace worldStrands
 {
     [CreateAssetMenu(fileName = "WorldStrandProfile", menuName = "WorldStrands/Profile", order = 0)]
-    public class WorldStrandProfile : ScriptableObject
+    public class worldStrandProfile : ScriptableObject
     {
         [System.Serializable]
         public struct ProfilePoint

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # worldstrands
 
-This repository contains a prototype Unity tool for generating stylized ropes with prayer flags. The initial implementation includes a `WorldStrandProfile` ScriptableObject and its custom Inspector UI. This profile defines the vertical cross‑section of a strand with positions and per‑vertex colors.
+This repository contains a prototype Unity tool for generating stylized ropes with prayer flags. The initial implementation includes a `worldStrandProfile` ScriptableObject and its custom Inspector UI. This profile defines the vertical cross‑section of a strand with positions and per‑vertex colors.
 
 Scripts are located under `assets/worldStrands/`.
 
 ## Strand Path Component
 
-`WorldStrandPath` is a `MonoBehaviour` that extrudes a `WorldStrandProfile` along a list of path points. Points can be adjusted directly in the Scene view and the generated mesh is stored in a `MeshFilter` on the same GameObject. The inspector now embeds the profile editor so you can tweak cross‑section points without leaving the component.
+`worldStrandPath` is a `MonoBehaviour` that extrudes a `worldStrandProfile` along a list of path points. Points can be adjusted directly in the Scene view and the generated mesh is stored in a `MeshFilter` on the same GameObject. The inspector now embeds the profile editor so you can tweak cross‑section points without leaving the component.


### PR DESCRIPTION
## Summary
- update namespaces to `worldStrands` and `worldStrands.editor`
- rename C# classes to match lowercase filenames
- update inspector code and docs

## Testing
- `for f in assets/worldStrands/*.cs assets/worldStrands/editor/*.cs; do basename=$(basename "$f" .cs); grep -m1 -E "class\s+${basename}\b" "$f" && echo "$f ok"; done`

------
https://chatgpt.com/codex/tasks/task_e_6878ea4363f483328a6d33b77b543c0f